### PR TITLE
new-cap: `newIsCap`

### DIFF
--- a/rulesets.js
+++ b/rulesets.js
@@ -161,7 +161,12 @@ module.exports.stylistic = {
     'error',
     5
   ],
-  'new-cap': 'warn',
+  'new-cap': [
+    'warn',
+    {
+      newIsCap: true
+    }
+  ],
   'no-array-constructor': 'warn',
   'no-lonely-if': 'error',
   'no-mixed-spaces-and-tabs': [


### PR DESCRIPTION
What do you think about this? A little more flexible, as it _just_ enforces anything with `new` is capped, instead of the other way around.

As is, it can potentially be annoying in situations like this:

```
const {Neutrino} = require('neutrino');
module.exports = Neutrino().call('eslintrc');
```

Our config will throw a warning, because `Neutrino` is used without `new`.
You could obviously import `as neutrino`, but that seems silly just to get around the linting.
I think in this particular case its exported as capital N because it's class-like, but not technically a constructor.
Seems like this could happen a lot in the funky land of js.

https://eslint.org/docs/rules/new-cap#options